### PR TITLE
Update to use bash-language-server 1.9.0

### DIFF
--- a/org.eclipse.shellwax.core/plugin.xml
+++ b/org.eclipse.shellwax.core/plugin.xml
@@ -6,7 +6,7 @@
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
             base-type="org.eclipse.core.runtime.text"
-            file-extensions="sh,bats"
+            file-extensions="sh,bats,inc,bash,command"
             id="org.eclipse.shellwax.sh"
             name="Shell Script"
             priority="normal">

--- a/org.eclipse.shellwax.core/src/org/eclipse/shellwax/internal/BashLanguageServer.java
+++ b/org.eclipse.shellwax.core/src/org/eclipse/shellwax/internal/BashLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Red Hat Inc. and others.
+ * Copyright (c) 2019, 2020 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,7 @@ import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 import org.eclipse.swt.widgets.Display;
 
 public class BashLanguageServer extends ProcessStreamConnectionProvider {
-	private static final String LS_VERSION = "1.7.0";
+	private static final String LS_VERSION = "1.9.0";
 	private static final String LOCAL_PATH = "/.local/share/shellwax/"+LS_VERSION;
 	private static final String LS_MAIN = "/node_modules/.bin/bash-language-server";
 	private static boolean alreadyWarned;


### PR DESCRIPTION
As per the server changelog
(https://github.com/mads-hartmann/bash-language-server/blob/master/server/CHANGELOG.md)
associate **/*@(.sh|.inc|.bash|.command) with the editor.

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>