### PR TITLE
Use bash-language-server 1.10

### DIFF
--- a/org.eclipse.shellwax.core/src/org/eclipse/shellwax/internal/BashLanguageServer.java
+++ b/org.eclipse.shellwax.core/src/org/eclipse/shellwax/internal/BashLanguageServer.java
@@ -29,7 +29,7 @@ import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 import org.eclipse.swt.widgets.Display;
 
 public class BashLanguageServer extends ProcessStreamConnectionProvider {
-	private static final String LS_VERSION = "1.9.0";
+	private static final String LS_VERSION = "1.10.0";
 	private static final String LOCAL_PATH = "/.local/share/shellwax/"+LS_VERSION;
 	private static final String LS_MAIN = "/node_modules/.bin/bash-language-server";
 	private static boolean alreadyWarned;


### PR DESCRIPTION
Changes in the LS:
* Improved completion handler and support auto-completion and
documentation for bash reserved words
(https://github.com/mads-hartmann/bash-language-server/pull/192)
* Upgrade tree-sitter


Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>