### PR TITLE
Update to bash-language-server 1.11.0

### DIFF
--- a/org.eclipse.shellwax.core/src/org/eclipse/shellwax/internal/BashLanguageServer.java
+++ b/org.eclipse.shellwax.core/src/org/eclipse/shellwax/internal/BashLanguageServer.java
@@ -29,7 +29,7 @@ import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 import org.eclipse.swt.widgets.Display;
 
 public class BashLanguageServer extends ProcessStreamConnectionProvider {
-	private static final String LS_VERSION = "1.10.0";
+	private static final String LS_VERSION = "1.11.0";
 	private static final String LOCAL_PATH = "/.local/share/shellwax/"+LS_VERSION;
 	private static final String LS_MAIN = "/node_modules/.bin/bash-language-server";
 	private static boolean alreadyWarned;


### PR DESCRIPTION
LS change:
* Support for workspace symbols
(https://github.com/mads-hartmann/bash-language-server/pull/195)


Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>