### PR TITLE
Update to Bash LS 1.16.1

### DIFF
--- a/org.eclipse.shellwax.core/src/org/eclipse/shellwax/internal/BashLanguageServer.java
+++ b/org.eclipse.shellwax.core/src/org/eclipse/shellwax/internal/BashLanguageServer.java
@@ -29,7 +29,7 @@ import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
 import org.eclipse.swt.widgets.Display;
 
 public class BashLanguageServer extends ProcessStreamConnectionProvider {
-	private static final String LS_VERSION = "1.13.0";
+	private static final String LS_VERSION = "1.16.1";
 	private static final String LOCAL_PATH = "/.local/share/shellwax/"+LS_VERSION;
 	private static final String LS_MAIN = "/node_modules/.bin/bash-language-server";
 	private static final String LS_MAIN_WIN32 = "/bash-language-server";


### PR DESCRIPTION
Language server changelog:
1.16.1

    Fix brace expansion bug
(https://github.com/bash-lsp/bash-language-server/pull/240)
    Do not crash if bash is not installed
(https://github.com/bash-lsp/bash-language-server/pull/242)

1.16.0

    Improved completion handler for parameter expansions
(https://github.com/bash-lsp/bash-language-server/pull/237)

1.15.0

    Use comments above symbols for documentation
(https://github.com/bash-lsp/bash-language-server/pull/234,
https://github.com/bash-lsp/bash-language-server/pull/235)

1.14.0

    onHover and onCompletion documentation improvements
(https://github.com/bash-lsp/bash-language-server/pull/230)
    support 0/1 as values for HIGHLIGHT_PARSING_ERRORS
(https://github.com/bash-lsp/bash-language-server/pull/231)

1.13.1

    Gracefully handle glob failures
(https://github.com/bash-lsp/bash-language-server/pull/224,
https://github.com/bash-lsp/bash-language-server/pull/226)
    Maintenance
(https://github.com/bash-lsp/bash-language-server/pull/222,
https://github.com/bash-lsp/bash-language-server/pull/225)


Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>