### PR TITLE
Fix for the Bash LS installation and startup

### DIFF
--- a/org.eclipse.shellwax.target/target-platform.target
+++ b/org.eclipse.shellwax.target/target-platform.target
@@ -3,7 +3,7 @@
 <target name="shellwax" sequenceNumber="5">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-	<repository location="http://download.eclipse.org/releases/2020-06/"/>
+	<repository location="http://download.eclipse.org/releases/2020-12/"/>
 	<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
 	<unit id="org.eclipse.platform.ide" version="0.0.0"/>
 	<unit id="org.eclipse.ui.genericeditor" version="0.0.0"/>


### PR DESCRIPTION
The change in BashLanguageServer (Shellwax) fixes the multiple bash LS installation job creation and invocation. 
A single static instance of  CompletableFuture is used to create and run a runnable for the Bash Language Server module installation. When `start()` API method is invoked it waits for this CompletableFuture to be resolved (which means the installation is finished) then starts the server.

This PR works best with this change https://git.eclipse.org/r/c/lsp4e/lsp4e/+/173719 to be applied on LSP4E, but doesn't require it for the normal functionality. 

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>