### PR TITLE
Add MacOS X/x86_64 and Linux/aarch64 environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,18 @@
 							<arch>x86_64</arch>
 						</environment>
 						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>aarch64</arch>
+						</environment>
+						<environment>
 							<os>win32</os>
 							<ws>win32</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
 							<arch>x86_64</arch>
 						</environment>
 					</environments>


### PR DESCRIPTION
So respective nodejs embedders are included in the repository.