### PR TITLE
ci: use actions/setup-java temurin distribution

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates

See : https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
