### PR TITLE
Update BashLS to 5.0.0

### DIFF
--- a/org.eclipse.shellwax.core/src/org/eclipse/shellwax/internal/BashLanguageServer.java
+++ b/org.eclipse.shellwax.core/src/org/eclipse/shellwax/internal/BashLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Red Hat Inc. and others.
+ * Copyright (c) 2019, 2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.wildwebdeveloper.embedder.node.NodeJSManager;
 
 public class BashLanguageServer extends ProcessStreamConnectionProvider {
-	private static final String LS_VERSION = "4.9.2";
+	private static final String LS_VERSION = "5.0.0";
 	private static final String LOCAL_PATH = "/.local/share/shellwax/"+LS_VERSION;
 	private static final String LS_MAIN = "/node_modules/.bin/bash-language-server";
 	private static final String LS_MAIN_WIN32 = "/bash-language-server";


### PR DESCRIPTION
Changes:
5.0.0

    Downgrade tree sitter to a stable version #911
    Drop support for Node.js 14 that is no longer maintained (security
updates ended 30 Apr 2023) #893
    Internal changes: switch from yarn classic to pnpm #893

4.10.3

    Use cat as man pager #909

4.10.2

    Bump semver development dependency causing false positive
distributions security warnings #905

4.10.1

    Handle tree-sitter-bash parse errors gracefully

4.10.0

    Upgrade tree-sitter-bash from 2022 November to 2023 May

4.9.3

    Fix flags/options insertion issue for some clients by using
textEdits #861
    Dependency upgrades

See https://github.com/bash-lsp/bash-language-server/blob/main/server/CHANGELOG.md#500 for full content.