### PR TITLE
Fix Jenkins warning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 	}
   agent {
     kubernetes {
-      label 'fedora-gtk3-mutter-java-node'
+      inheritFrom 'fedora-gtk3-mutter-java-node'
       defaultContainer 'jnlp'
       yaml """
 apiVersion: v1


### PR DESCRIPTION
"[WARNING] label option is deprecated. To use a static pod template, use the 'inheritFrom' option."